### PR TITLE
fix(jvm): regex should also find partial matches

### DIFF
--- a/jvm/src/main/scala/org/molgenis/expression/Expressions.scala
+++ b/jvm/src/main/scala/org/molgenis/expression/Expressions.scala
@@ -19,7 +19,7 @@ class Expressions(val maxCacheSize: Int = 1000) {
 
   private def regex: List[Any] => Boolean = {
     case List(_, null)              => false
-    case List(a: String, b: String) => Pattern.compile(a).matcher(b).matches
+    case List(a: String, b: String) => Pattern.compile(a).matcher(b).find
     case List(a: String, b: String, flags: String) =>
       val flag: Int = flags.toList.foldLeft(0)((flags, flagChar) =>
         flagChar match {
@@ -30,7 +30,7 @@ class Expressions(val maxCacheSize: Int = 1000) {
             throw new IllegalArgumentException(s"Unknown regex flag: $x")
         }
       )
-      Pattern.compile(a, flag).matcher(b).matches
+      Pattern.compile(a, flag).matcher(b).find
   }
 
   private def toLocalDate(value: Any): Option[LocalDate] =

--- a/jvm/src/test/scala/org/molgenis/expression/ExpressionsSpec.scala
+++ b/jvm/src/test/scala/org/molgenis/expression/ExpressionsSpec.scala
@@ -55,6 +55,28 @@ class ExpressionsSpec extends AnyFlatSpec with Tables {
     )
   }
 
+  it should "find partial matches" in {
+    val javaExpressions = util.List.of(
+      """regex('^[cgmnopr]\\.', {hgvs})"""
+    )
+    val javaContext = util.Map.of[String, Any]("hgvs", "c.2739delT")
+    assert(
+      expressions.parseAndEvaluate(javaExpressions, javaContext) == util.List
+        .of(Success(true))
+    )
+  }
+
+  it should "find partial matches with flags" in {
+    val javaExpressions = util.List.of(
+      """regex('^[cgmnopr]\\.', {hgvs}, 'i')"""
+    )
+    val javaContext = util.Map.of[String, Any]("hgvs", "C.2739delT")
+    assert(
+      expressions.parseAndEvaluate(javaExpressions, javaContext) == util.List
+        .of(Success(true))
+    )
+  }
+
   "age" should "be one if your first birthday is today" in {
     val todayAYearAgo: LocalDate = LocalDate.now(ZoneOffset.UTC).minusYears(1)
 


### PR DESCRIPTION
The JS regex also finds partial matches, the JVM regex tries to match the full string